### PR TITLE
Allow column_name and arrays in column options

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -137,6 +137,8 @@ InitChFdwOptions(void)
 		{"driver", ForeignServerRelationId, false},
 		{"aggregatefunction", AttributeRelationId, false},
 		{"simpleaggregatefunction", AttributeRelationId, false},
+		{"column_name", AttributeRelationId, false},
+		{"arrays", AttributeRelationId, false},
 		{NULL, InvalidOid, false}
 	};
 


### PR DESCRIPTION
Both column_name and arrays are already supported as options in https://github.com/gh56123/clickhouse_fdw/blob/master/src/custom_types.c#L522-L539

Before this patch:

```
ALTER FOREIGN TABLE foreign_table ALTER COLUMN pg_column_name OPTIONS (
 	    column_name 'column_name_as_in_clickhouse'
 	);
ERROR:  invalid option "column_name"
HINT:  Valid options in this context are: aggregatefunction, simpleaggregatefunction
```