### PR TITLE
perf: make TCP_NODELAY configurable to improve query performance

### DIFF
--- a/src/clickhouse-cpp/clickhouse/base/socket.cpp
+++ b/src/clickhouse-cpp/clickhouse/base/socket.cpp
@@ -169,6 +169,11 @@ void SocketHolder::SetTcpKeepAlive(int idle, int intvl, int cnt) noexcept {
 #endif
 }
 
+void SocketHolder::SetTcpNoDelay(bool nodelay) noexcept {
+    int val = nodelay;
+    setsockopt(handle_, IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val));
+}
+
 SocketHolder& SocketHolder::operator = (SocketHolder&& other) noexcept {
     if (this != &other) {
         Close();

--- a/src/clickhouse-cpp/clickhouse/base/socket.h
+++ b/src/clickhouse-cpp/clickhouse/base/socket.h
@@ -62,6 +62,9 @@ public:
     ///         before dropping the connection.
     void SetTcpKeepAlive(int idle, int intvl, int cnt) noexcept;
 
+    /// @params nodelay whether to enable TCP_NODELAY
+    void SetTcpNoDelay(bool nodelay) noexcept;
+
     SocketHolder& operator = (SocketHolder&& other) noexcept;
 
     operator SOCKET () const noexcept;

--- a/src/clickhouse-cpp/clickhouse/client.cpp
+++ b/src/clickhouse-cpp/clickhouse/client.cpp
@@ -356,6 +356,10 @@ void Client::Impl::ResetConnection() {
                           options_.tcp_keepalive_cnt);
     }
 
+    if (options_.tcp_nodelay) {
+        s.SetTcpNoDelay(options_.tcp_nodelay);
+    }
+
     socket_ = std::move(s);
     socket_input_ = SocketInput(socket_);
     socket_output_ = SocketOutput(socket_);

--- a/src/clickhouse-cpp/clickhouse/client.h
+++ b/src/clickhouse-cpp/clickhouse/client.h
@@ -80,6 +80,9 @@ struct ClientOptions {
     DECLARE_FIELD(tcp_keepalive_intvl, std::chrono::seconds, SetTcpKeepAliveInterval, std::chrono::seconds(5));
     DECLARE_FIELD(tcp_keepalive_cnt, unsigned int, SetTcpKeepAliveCount, 3);
 
+    // TCP NoDelay Options
+    DECLARE_FIELD(tcp_nodelay, bool, TcpNoDelay, true);
+
 #undef DECLARE_FIELD
 };
 


### PR DESCRIPTION
### Motivation

In real-world testing, we observed that data insertion and query latency via `clickhouse_fdw` is significantly higher than using the native `clickhouse-client`. This gap becomes more pronounced in batch insert workloads.

Upon investigation, it was found that `clickhouse-client` explicitly enables the `TCP_NODELAY` socket option:
- https://github.com/ClickHouse/ClickHouse/blob/c0d1416bbd564fa1e9b3ae5e58b1a5785b5d891a/src/Client/Connection.cpp#L91
- This behavior is also reflected in the lastest `clickhouse-cpp` library:  
  https://github.com/ClickHouse/clickhouse-cpp/blob/master/clickhouse/client.h#L112

Enabling `TCP_NODELAY` disables Nagle's algorithm, reducing latency for interactive or burst-style small-packet transmissions, which is especially beneficial for PostgreSQL foreign data wrapper scenarios.

---

### What this PR does

- Introduces a new foreign server option `tcp_nodelay` (default: true)
- When enabled, `TCP_NODELAY` is applied to the underlying socket for ClickHouse connections
- Improves performance of high-volume inserts over FDW

---

### Performance Test

ClickHouse table schema:

```sql
CREATE TABLE test_database.user_events
(
    id UInt32,
    user_id UInt32,
    event_type String,
    event_time DateTime,
    is_active UInt8,
    score Float64,
    comment String
)
ENGINE = MergeTree()
ORDER BY id;
```


A sample test was conducted using PostgreSQL 16.x and ClickHouse 24.1.x, inserting 100,000 records in 10 batches using a PL/pgSQL DO block:

```sql
DO $$
DECLARE
    i integer;
BEGIN
    FOR i IN 0..9 LOOP
        INSERT INTO user_events
        SELECT
            i * 10000 + gs AS id,
            (random() * 1000)::int AS user_id,
            CASE WHEN random() > 0.5 THEN 'click' ELSE 'view' END AS event_type,
            now() - (random() * interval '10 days') AS event_time,
            (random() > 0.5)::int AS is_active,
            round((random() * 100)::numeric, 2) AS score,
            'This is event #' || (i * 10000 + gs) AS comment
        FROM generate_series(1, 10000) AS gs;
    END LOOP;
END
$$;
```


#### Without tcp_nodelay:
- 638.542 ms
- 636.483 ms
- 657.837 ms
- 547.108 ms
- 627.309 ms

#### With tcp_nodelay = 'true':
- 492.553 ms
- 505.970 ms
- 505.632 ms
- 491.527 ms
- 506.315 ms

~20% latency reduction in batch insert performance.