### PR TITLE
Fix compile error on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,10 @@ exec_program(${PG_CONFIG} ARGS --bindir OUTPUT_VARIABLE PGSQL_BINDIR)
 exec_program(${PG_CONFIG} ARGS --cppflags OUTPUT_VARIABLE PGSQL_CPPFLAGS)
 exec_program(${PG_CONFIG} ARGS --ldflags OUTPUT_VARIABLE PGSQL_LDFLAGS)
 exec_program(${PG_CONFIG} ARGS --libs OUTPUT_VARIABLE PGSQL_LIBS)
+if(APPLE)
+string(REGEX REPLACE "-isysroot[ ]+[^ ]+ " "" PGSQL_LDFLAGS ${PGSQL_LDFLAGS})
+string(REGEX REPLACE "-isysroot[ ]+[^ ]+ " "" PGSQL_CPPFLAGS ${PGSQL_CPPFLAGS})
+endif(APPLE)
 
 #------------------------------------------------------------------------------
 # tests


### PR DESCRIPTION
Fix compile error on macOS

I was getting this error on macOS:

```
ld: library 'c++' not found
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

Took a while to track down the issue, but it turned out this warning at the end of `cmake` was key:

```
CMake Warning at src/CMakeLists.txt:40 (target_link_libraries):
  Target "clickhouse_fdw" requests linking to directory
  "/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk".  Targets may link
  only to libraries.  CMake is dropping the item.
```

This is fine, except that that CMake doesn't remove the option this directory points to. The option is stored by `pg_config`; you can see it here:

``` console
pg_config --ldflags         
-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.5.sdk -L/opt/homebrew/opt/readline/lib -Wl,-dead_strip_dylibs
```

What we need to do is remove both the macOS SDK and `-isysroot`. So add a section to `CMakeLists.txt` that uses `REGEX REPLACE` to remove the complete option from the output of `pg_config` on macOS.